### PR TITLE
Render a proper error page

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "17",
   "build_system": "gradle-kotlin",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "backend:ErrorHandlingTests"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/backend/src/main/kotlin/petklinik/backend/GlobalRouter.kt
+++ b/backend/src/main/kotlin/petklinik/backend/GlobalRouter.kt
@@ -1,14 +1,61 @@
 package petklinik.backend
 
+import jakarta.servlet.RequestDispatcher
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
+import org.springframework.web.servlet.function.ServerResponse
 import org.springframework.web.servlet.function.router
+import petklinik.common.renderError
 import petklinik.common.renderWelcome
 
 fun globalRouter() = router {
     GET("/") {
         ok().contentType(MediaType.TEXT_HTML).body(renderWelcome())
     }
+
+    // Explicit error endpoint to replace Spring Boot Whitelabel page and render full UI
+    GET("/error") { request ->
+        val code = request.servletRequest().getAttribute(RequestDispatcher.ERROR_STATUS_CODE) as? Int
+        val exception = request.servletRequest().getAttribute(RequestDispatcher.ERROR_EXCEPTION) as? Throwable
+        val requestUri = request.servletRequest().getAttribute(RequestDispatcher.ERROR_REQUEST_URI) as? String
+        
+        val title = when (code) {
+            404 -> "Page Not Found"
+            403 -> "Access Forbidden"
+            500 -> "Internal Server Error"
+            else -> "Something went wrong"
+        }
+        
+        val message = when (code) {
+            404 -> "The page you're looking for at '$requestUri' could not be found. It may have been moved, deleted, or you entered the wrong URL."
+            403 -> "You don't have permission to access this resource."
+            500 -> exception?.message ?: "An internal server error occurred. Please try again later."
+            else -> exception?.message ?: code?.let { "HTTP $it: " + HttpStatus.valueOf(it).reasonPhrase }
+        }
+        
+        ServerResponse.status(code?.let { HttpStatus.valueOf(it) } ?: HttpStatus.INTERNAL_SERVER_ERROR)
+            .contentType(MediaType.TEXT_HTML)
+            .body(renderError(title = title, message = message))
+    }
+
+    // Demo endpoint that triggers an exception
     GET("/oups") {
         throw RuntimeException("Expected: controller used to showcase what happens when an exception is thrown")
+    }
+
+    // Global error handler to render the full UI with error content
+    onError<Throwable> { exception, request ->
+        val title = when (exception) {
+            is IllegalArgumentException -> "Invalid Request"
+            is SecurityException -> "Security Error"
+            is RuntimeException -> "Runtime Error"
+            else -> "Unexpected Error"
+        }
+        
+        val message = exception.message ?: "An unexpected error occurred while processing your request."
+        
+        ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .contentType(MediaType.TEXT_HTML)
+            .body(renderError(title = title, message = message))
     }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -9,3 +9,6 @@ spring.threads.virtual.enabled=true
 image.generator.url=http://localhost:8081/generate
 
 spring.docker.compose.profiles.active=db
+
+# Disable default Whitelabel error page since we provide a custom error handler
+server.error.whitelabel.enabled=false

--- a/backend/src/test/kotlin/petklinik/backend/ErrorHandlingTests.kt
+++ b/backend/src/test/kotlin/petklinik/backend/ErrorHandlingTests.kt
@@ -1,0 +1,83 @@
+package petklinik.backend
+
+import jakarta.servlet.RequestDispatcher
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+class ErrorHandlingTests {
+
+    private val mockMvc: MockMvc = MockMvcBuilders.routerFunctions(globalRouter()).build()
+
+    @Test
+    fun `oups endpoint should render custom error page with 500 and exception message`() {
+        mockMvc.get("/oups").andExpect {
+            status { isInternalServerError() }
+            content { contentTypeCompatibleWith(MediaType.TEXT_HTML) }
+            content { string(org.hamcrest.Matchers.containsString("Runtime Error")) }
+            content { string(org.hamcrest.Matchers.containsString("alert alert-danger")) }
+            content {
+                string(
+                        org.hamcrest.Matchers.containsString(
+                                "Expected: controller used to showcase what happens when an exception is thrown"
+                        )
+                )
+            }
+            // Verify it includes full UI layout
+            content { string(org.hamcrest.Matchers.containsString("navbar navbar-default")) }
+            content { string(org.hamcrest.Matchers.containsString("Return to Home")) }
+        }
+    }
+
+    @Test
+    fun `error endpoint should use provided status code and render full UI`() {
+        mockMvc
+                .get("/error") {
+                    requestAttr(RequestDispatcher.ERROR_STATUS_CODE, 404)
+                    requestAttr(RequestDispatcher.ERROR_REQUEST_URI, "/nonexistent")
+                }
+                .andExpect {
+                    status { isNotFound() }
+                    content { contentTypeCompatibleWith(MediaType.TEXT_HTML) }
+                    // Should include enhanced 404 error message
+                    content { string(org.hamcrest.Matchers.containsString("Page Not Found")) }
+                    content {
+                        string(
+                                org.hamcrest.Matchers.containsString(
+                                        "'/nonexistent' could not be found"
+                                )
+                        )
+                    }
+                    // Basic layout elements to ensure full UI shell
+                    content {
+                        string(org.hamcrest.Matchers.containsString("navbar navbar-default"))
+                    }
+                    content { string(org.hamcrest.Matchers.containsString("jumbotron")) }
+                    content { string(org.hamcrest.Matchers.containsString("Return to Home")) }
+                }
+    }
+
+    @Test
+    fun `error endpoint should handle 500 errors with proper message`() {
+        mockMvc.get("/error") { requestAttr(RequestDispatcher.ERROR_STATUS_CODE, 500) }.andExpect {
+            status { isInternalServerError() }
+            content { contentTypeCompatibleWith(MediaType.TEXT_HTML) }
+            content { string(org.hamcrest.Matchers.containsString("Internal Server Error")) }
+            content { string(org.hamcrest.Matchers.containsString("navbar navbar-default")) }
+            content { string(org.hamcrest.Matchers.containsString("jumbotron")) }
+        }
+    }
+
+    @Test
+    fun `error endpoint should handle 403 errors with proper message`() {
+        mockMvc.get("/error") { requestAttr(RequestDispatcher.ERROR_STATUS_CODE, 403) }.andExpect {
+            status { isForbidden() }
+            content { contentTypeCompatibleWith(MediaType.TEXT_HTML) }
+            content { string(org.hamcrest.Matchers.containsString("Access Forbidden")) }
+            content { string(org.hamcrest.Matchers.containsString("don't have permission")) }
+            content { string(org.hamcrest.Matchers.containsString("navbar navbar-default")) }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/petklinik/common/Menu.kt
+++ b/shared/src/commonMain/kotlin/petklinik/common/Menu.kt
@@ -1,5 +1,5 @@
 package petklinik.common
 
 enum class Menu {
-    HOME, OWNERS, VETS
+    HOME, OWNERS, VETS, ERROR
 }

--- a/shared/src/commonMain/kotlin/petklinik/common/RenderError.kt
+++ b/shared/src/commonMain/kotlin/petklinik/common/RenderError.kt
@@ -1,0 +1,58 @@
+package petklinik.common
+
+import kotlinx.html.*
+
+/**
+ * Renders a full UI page with an error message inside the common layout. This custom error page
+ */
+fun renderError(title: String = "Oops! Something went wrong", message: String? = null) =
+        renderLayout(Menu.ERROR) {
+            div(classes = "jumbotron") {
+                div(classes = "container") {
+                    h2(classes = "display-4") { +title }
+                    p(classes = "lead") {
+                        +"An unexpected error occurred. Please try again or contact support if the problem persists."
+                    }
+                    hr(classes = "my-4")
+                    if (!message.isNullOrBlank()) {
+                        h4 { +"Error Details:" }
+                        div(classes = "alert alert-danger") {
+                            attributes["role"] = "alert"
+                            p { +message }
+                        }
+                    } else {
+                        div(classes = "alert alert-warning") {
+                            attributes["role"] = "alert"
+                            p { +"No specific error details are available." }
+                        }
+                    }
+                    div(classes = "mt-4") {
+                        a(classes = "btn btn-primary btn-lg", href = "/") {
+                            attributes["role"] = "button"
+                            +"Return to Home"
+                        }
+                        a(
+                                classes = "btn btn-secondary btn-lg ml-2",
+                                href = "javascript:history.back()"
+                        ) {
+                            attributes["role"] = "button"
+                            +"Go Back"
+                        }
+                    }
+                }
+            }
+
+            div(classes = "container mt-4") {
+                div(classes = "row") {
+                    div(classes = "col-md-6") {
+                        h3 { +"What can you do?" }
+                        ul {
+                            li { +"Try refreshing the page" }
+                            li { +"Check if the URL is correct" }
+                            li { +"Return to the home page and try again" }
+                            li { +"Contact support if the problem persists" }
+                        }
+                    }
+                }
+            }
+        }

--- a/shared/src/commonMain/kotlin/petklinik/common/RenderLayout.kt
+++ b/shared/src/commonMain/kotlin/petklinik/common/RenderLayout.kt
@@ -83,6 +83,9 @@ fun renderLayout(activeMenu: Menu, layoutContent: DIV.() -> Unit = {}) = createH
                             }
                         }
                         li {
+                            if (activeMenu == Menu.ERROR) {
+                                classes = setOf("active")
+                            }
                             a(href="/oups") {
                                 title = "trigger a RuntimeException to see how it is handled"
                                 span(classes ="glyphicon glyphicon-warning-sign")


### PR DESCRIPTION
Currently the error page (accessible from the UI) is not rendered inside the application but rather rendered as the default Spring Boot Whitelabel Error Page with the message: `This application has no explicit mapping for /error, so you are seeing this as a fallback.`
Implement a proper error handling page that will render the whole UI and show the error explicitly as content


